### PR TITLE
Added quasi class for es6 template literal placeholders

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -9,6 +9,10 @@
   }
 }
 
+.quasi {
+  color: @syntax-accent;
+}
+
 .entity {
 
   &.name.type {


### PR DESCRIPTION
This is my favorite syntax theme so I updated it to support ES6 template literal place holders.

Check out image for before and after:

![template-literal-support](https://cloud.githubusercontent.com/assets/16612438/18426270/7f893ac0-787d-11e6-9a8d-1221194749cb.png)
