### PR TITLE
Fixed invisible character styling

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -26,7 +26,7 @@ atom-text-editor {
     box-sizing: border-box;
   }
 
-  .syntax--invisible-character {
+  .invisible-character {
     color: @syntax-invisible-character-color;
   }
 


### PR DESCRIPTION
Removed --syntax from .invisible-character following my previous PR. Appears it didn't need to be changed.

Ref: #8 